### PR TITLE
Adding "cleanup unpacked WAR directory" function before tomcat starting.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Changes
+[1.1.4]: https://github.com/sunggun-yu/capitomcat/releases/tag/v1.1.4
 [1.1.3]: https://github.com/sunggun-yu/capitomcat/releases/tag/v1.1.3
 [1.1.2]: https://github.com/sunggun-yu/capitomcat/releases/tag/v1.1.2
 [1.1.1]: https://github.com/sunggun-yu/capitomcat/releases/tag/v1.1.1
@@ -6,6 +7,11 @@
 [1.0.1]: https://github.com/sunggun-yu/capitomcat/releases/tag/v1.0.1
 [1.0.0]: https://github.com/sunggun-yu/capitomcat/releases/tag/v1.0.0
 [0.0.3]: https://github.com/sunggun-yu/capitomcat/releases/tag/v0.0.3
+
+## [v1.1.4][1.1.4]
+ * Adding "cleanup unpacked WAR directory" function before tomcat starting.
+    * Unpacked WAR directory is not refreshed. eventually, Tomcat doesn't provide latest changes in new WAR file by this issue.
+    * Thanks to @jwcarman
 
 ## [v1.1.3][1.1.3]
  * Bug Fix : There was space between "-" and "u" at Tomcat work directory cleaning task.

--- a/examples/recipe/singlestage/lib/capistrano/tasks/tomcat_webapp.cap
+++ b/examples/recipe/singlestage/lib/capistrano/tasks/tomcat_webapp.cap
@@ -17,7 +17,7 @@ set :tomcat_user_group, 'tomcat7'
 set :tomcat_port, '8080'
 set :tomcat_cmd, '/etc/init.d/tomcat7'
 set :use_tomcat_user_cmd, false
-set :tomcat_war_file, '/var/app/war/test-web.war'
+set :tomcat_war_file, '/var/lib/tomcat7/webapps/test-web.war'
 set :tomcat_context_path, '/test-web'
 set :tomcat_context_file, '/var/lib/tomcat7/conf/Catalina/localhost/test-web.xml'
 set :tomcat_work_dir, '/var/lib/tomcat7/work/Catalina/localhost/test-web'

--- a/lib/capitomcat/tasks/deploy.cap
+++ b/lib/capitomcat/tasks/deploy.cap
@@ -57,6 +57,9 @@ namespace :capitomcat do
         stop_tomcat
         check_tomcat_stopped
 
+        info 'Clean Unpacked WAR directory'
+        cleanup_unpacked_dir
+
         info 'Upload WAR file'
         upload_war_file
 

--- a/lib/capitomcat/version.rb
+++ b/lib/capitomcat/version.rb
@@ -1,3 +1,3 @@
 module Capitomcat
-  VERSION = '1.1.3'
+  VERSION = '1.1.4'
 end


### PR DESCRIPTION
- Unpacked WAR directory is not refreshed. eventually, Tomcat doesn't provide latest changes in new WAR file by this issue.
- Thanks to @jwcarman
