### PR TITLE
Tomcat check with curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# Capitomcat
-[![Gem Version](https://badge.fury.io/rb/capitomcat.png)](http://badge.fury.io/rb/capitomcat)
+# Capitomcat-ELB
+Capitomcat-ELB is a library for deploying Tomcat applications, served behind AWS Elastic Loadbalancers.
+Capitomcat-ELB will perform a rolling restart on your application, de-registering the instances in sequence to avoid downtime.
 
-Capitomcat is library for creating Capistrano Tomcat recipe.
-Capitomcat includes basic tasks for Tomcat deployment. You can create easily your own Capistrano 3 recipe for Tomcat with Capitomcat.
+Originally forked from:
+ https://github.com/jenkinsci/capitomcat-plugin
 
 ##See Also
 ### Capitomcat Jenkins Plugin
@@ -36,7 +37,7 @@ Add your SSH key into `authorized_keys` file of `deploy` user on your remote ser
 Folowing NOPASSWD setting is required. please add following setting into your `/etc/sudoers` file.
 ```` sh
 %your_deploy_user_name ALL=NOPASSWD:/etc/init.d/tomcat7 <Your tomcat command>
-%your_deploy_user_name ALL=NOPASSWD: /bin/chown 
+%your_deploy_user_name ALL=NOPASSWD: /bin/chown
 %your_deploy_user_name ALL=(<your_tomcat_user> : <your_tomcat_user_group>) NOPASSWD: ALL
 ````
 
@@ -55,16 +56,32 @@ $ gem install capistrano -v 3.0.1
 ###Install Capitomcat
 ``` sh
 $ gem install capitomcat
-```	
+```
 
 ##Configuration
 ### Role Configuration
 <pre>
 role :app, %w{deploy@dev01 deploy@dev02}
 </pre>
+
+<pre>
+server fetch('deploy@dev01'),
+  ...
+  instance_id: 'ec2-instance-id',
+  ...
+end
+</pre>
+
 ### Required configuration for Capitomcat
 <pre>
 set :use_sudo, true
+
+# Loadbalancer config
+set :aws_access_key_id, 'XXXYYY'
+set :aws_region, 'eu-west-1'
+set :aws_secret_access_key, 'xxxyyyzzz'
+set :elb_instance_registration_wait_seconds, 300 #optional
+set :load_balancer_name, 'elb-name'
 
 # Remote Tomcat server setting section
 set :tomcat_user, 'tomcat7'

--- a/lib/capitomcat/aws_elb_manager.rb
+++ b/lib/capitomcat/aws_elb_manager.rb
@@ -1,0 +1,55 @@
+module Capitomcat
+  class AwsElbManager
+    def initialize(region:, access_key_id:, secret_access_key:, load_balancer_name:)
+      @load_balancer_name = load_balancer_name
+
+      @client = Aws::ElasticLoadBalancing::Client.new(
+        access_key_id: access_key_id,
+        region: region,
+        secret_access_key: secret_access_key)
+    end
+
+    def deregister_instance(instance_id)
+      client.deregister_instances_from_load_balancer(
+        {
+          load_balancer_name: load_balancer_name,
+          instances: [
+            {
+              instance_id: instance_id
+            }
+          ]
+        }
+      )
+    end
+
+    def register_instance(instance_id)
+      client.register_instances_with_load_balancer(
+        {
+          load_balancer_name: load_balancer_name,
+          instances: [
+            {
+              instance_id: instance_id
+            }
+          ]
+        }
+      )
+    end
+
+    def instance_state(instance_id)
+      client.describe_instance_health(
+        {
+          load_balancer_name: load_balancer_name,
+          instances: [
+            {
+              instance_id: instance_id
+            }
+          ]
+        }
+      ).instance_states.first.state
+    end
+
+    private
+
+    attr_reader :load_balancer_name, :client
+  end
+end

--- a/lib/capitomcat/tasks/deploy.cap
+++ b/lib/capitomcat/tasks/deploy.cap
@@ -1,5 +1,7 @@
 require 'capistrano'
+require 'aws-sdk'
 require 'sshkit/backends/netssh'
+require_relative '../aws_elb_manager'
 
 # Author:: Sunggun Yu
 
@@ -35,7 +37,26 @@ namespace :capitomcat do
   DESC
 
   task :deploy do
+    set :elb_instance_registration_wait_seconds, 300
+
+    aws_elb_manager = Capitomcat::AwsElbManager.new(
+      access_key_id: fetch(:aws_access_key_id),
+      region: fetch(:aws_region),
+      secret_access_key: fetch(:aws_secret_access_key),
+      load_balancer_name: fetch(:load_balancer_name)
+    )
+
     on roles(:app), in: get_parallelism, wait: 5 do |hosts|
+      current_instance_id = hosts.properties.fetch(:instance_id)
+
+      aws_elb_manager.deregister_instance(current_instance_id)
+      info 'Waiting for instance to be deregistered from Loadbalancer'
+      wait_for_instance_state(
+        aws_elb_manager: aws_elb_manager,
+        instance_id: current_instance_id,
+        state: 'OutOfService'
+      )
+
       local_war_file = fetch(:local_war_file)
       tomcat_war_file = fetch(:tomcat_war_file)
 
@@ -54,6 +75,14 @@ namespace :capitomcat do
       info 'Start Tomcat'
       start_tomcat
       check_tomcat_started
+
+      aws_elb_manager.register_instance(current_instance_id)
+      info 'Waiting for instance to be registered with Loadbalancer'
+      wait_for_instance_state(
+        aws_elb_manager: aws_elb_manager,
+        instance_id: current_instance_id,
+        state: 'InService'
+      )
     end
   end
 
@@ -308,5 +337,21 @@ namespace :capitomcat do
     _test = capture("echo `if [ -e '#{file}' ] ; then echo 'true' ; else echo 'false' ; fi`").to_s
 
     _test.eql?('true')
+  end
+
+  def wait_for_instance_state(instance_id:, state:, aws_elb_manager:)
+    count = 0
+
+    begin
+      instance_state = aws_elb_manager.instance_state(instance_id)
+
+      info "#{instance_id} state is: #{instance_state}"
+      sleep(1)
+      count += 1
+
+      if count >= fetch(:elb_instance_registration_wait_seconds)
+        raise "Instance: #{instance_id} not in #{instance_state} after #{count} seconds"
+      end
+    end until(instance_state == state)
   end
 end

--- a/lib/capitomcat/tasks/deploy.cap
+++ b/lib/capitomcat/tasks/deploy.cap
@@ -124,7 +124,7 @@ namespace :capitomcat do
                               30 # Default is 30 sec
                             end
     _times = 0
-    until check_netstat_tomcat_port do
+    until check_tomcat_responding do
       if _times >= tomcat_cmd_wait_start
         raise 'Tomcat is not started.'
       end
@@ -142,7 +142,7 @@ namespace :capitomcat do
                               5 # Default is 5 sec
                             end
     _times = 0
-    until !check_netstat_tomcat_port do
+    until !check_tomcat_responding do
       if _times >= tomcat_cmd_wait_stop
         raise 'Tomcat is not stopped.'
       end
@@ -152,14 +152,8 @@ namespace :capitomcat do
     end
   end
 
-  # Do netstat -an | grep ${tomcat_port} | grep "LISTEN" to check whether tomcat port is up or not. return when it is up.
-  def check_netstat_tomcat_port
-    tomcat_port = fetch(:tomcat_port)
-    _netstat = capture("netstat -an | grep \"#{tomcat_port}\" | grep \"LISTEN\" ; echo \"\"")
-    info (_netstat)
-    if _netstat.to_s.length > 1
-      return true
-    end
+  def check_tomcat_responding
+    test("curl -I 'http://127.0.0.1:#{tomcat_port}'")
   end
 
   # Stop Tomcat server

--- a/lib/capitomcat/tasks/deploy.cap
+++ b/lib/capitomcat/tasks/deploy.cap
@@ -42,8 +42,8 @@ namespace :capitomcat do
       if local_war_file.is_a?(Array) and tomcat_war_file.is_a?(Array)
         raise("Local and Remote files must match") if local_war_file.length != tomcat_war_file.length
 
-        local_war_file.times do |i|
-          deploy_war(local_war_file[i], tomcat_war_file[i])
+        local_war_file.each_with_index do |local_file, index|
+          deploy_war(local_file, tomcat_war_file[index])
         end
       elsif local_war_file.is_a?(String) and fetch(:tomcat_war_file).is_a?(String)
         deploy_war(local_war_file, tomcat_war_file)

--- a/lib/capitomcat/tasks/deploy.cap
+++ b/lib/capitomcat/tasks/deploy.cap
@@ -33,58 +33,67 @@ namespace :capitomcat do
     set   :use_parallel, true
     set   :use_context_update, true
   DESC
+
   task :deploy do
     on roles(:app), in: get_parallelism, wait: 5 do |hosts|
-      if fetch(:use_context_update) then
-        info 'Upload WAR file'
-        upload_war_file
-
-        info 'Stop Tomcat'
-        stop_tomcat
-        check_tomcat_stopped
-
-        info 'Update Context'
-        upload_context_file
-
-        info 'Clean Work directory'
-        cleanup_work_dir
-
-        info 'Clean Unpacked WAR directory'
-        cleanup_unpacked_dir
-
-        info 'Start Tomcat'
-        start_tomcat
-        check_tomcat_started
+      if fetch(:local_war_file).is_a?(Array) and fetch(:tomcat_war_file).is_a?(Array)
+        deploy_war(fetch(:local_war_file), fetch(:tomcat_war_file))
+      elsif fetch(:local_war_file).is_a?(String) and fetch(:tomcat_war_file).is_a?(String)
+        deploy_war(fetch(:local_war_file), fetch(:tomcat_war_file))
       else
-        info 'Stop Tomcat'
-        stop_tomcat
-        check_tomcat_stopped
-
-        info 'Clean Unpacked WAR directory'
-        cleanup_unpacked_dir
-
-        info 'Upload WAR file'
-        upload_war_file
-
-        info 'Clean Work directory'
-        cleanup_work_dir
-
-        info 'Start Tomcat'
-        start_tomcat
-        check_tomcat_started
+        raise("War inputs are mismatched")
       end
+    end
+  end
+
+  def deploy_war(local_war_file, tomcat_war_file)
+    if fetch(:use_context_update) then
+      info 'Upload WAR file'
+      upload_war_file(local_war_file, tomcat_war_file)
+
+      info 'Stop Tomcat'
+      stop_tomcat
+      check_tomcat_stopped
+
+      info 'Update Context'
+      upload_context_file
+
+      info 'Clean Work directory'
+      cleanup_work_dir
+
+      info 'Clean Unpacked WAR directory'
+      cleanup_unpacked_dir(tomcat_war_file)
+
+      info 'Start Tomcat'
+      start_tomcat
+      check_tomcat_started
+    else
+      info 'Stop Tomcat'
+      stop_tomcat
+      check_tomcat_stopped
+
+      info 'Clean Unpacked WAR directory'
+      cleanup_unpacked_dir(tomcat_war_file)
+
+      info 'Upload WAR file'
+      upload_war_file(local_war_file, tomcat_war_file)
+
+      info 'Clean Work directory'
+      cleanup_work_dir
+
+      info 'Start Tomcat'
+      start_tomcat
+      check_tomcat_started
     end
   end
 
   # Start Tomcat server
   def start_tomcat
-    # local variables
     execute_tomcat_cmd('start')
   end
 
   # Check status whether Tomcat started
   def check_tomcat_started
-    # local variables
     tomcat_cmd_wait_start = if fetch(:tomcat_cmd_wait_start).to_s.length > 0
                               fetch(:tomcat_cmd_wait_start).to_i
                             else
@@ -103,7 +112,6 @@ namespace :capitomcat do
 
   # Check status whether Tomcat stopped
   def check_tomcat_stopped
-    # local variables
     tomcat_cmd_wait_stop = if fetch(:tomcat_cmd_wait_stop).to_s.length > 0
                               fetch(:tomcat_cmd_wait_stop).to_i
                             else
@@ -136,11 +144,8 @@ namespace :capitomcat do
   end
 
   # Upload the WAR file
-  def upload_war_file
-    # local variables
+  def upload_war_file(local_war_file, tomcat_war_file)
     upload_user = fetch(:user)
-    local_war_file = fetch(:local_war_file)
-    tomcat_war_file = fetch(:tomcat_war_file)
     tomcat_user = fetch(:tomcat_user)
 
     if File.exists?(local_war_file)
@@ -161,17 +166,11 @@ namespace :capitomcat do
   end
 
   # Generate context.xml file string from ERB template file and bindings
-  def get_context_template
-    # local variables
-    context_template_file = fetch(:context_template_file)
+  def get_context_template(context_template_file, tomcat_war_file)
+    raise('Context template file does not existing.') if !File.exists?(context_template_file)
 
-    if !File.exists?(context_template_file)
-      raise('Context template file does not existing.')
-    end
-
-    # local variables for erb file
+  for erb file
     tomcat_context_path = fetch(:tomcat_context_path)
-    tomcat_war_file = fetch(:tomcat_war_file)
     info ("#{tomcat_context_path}, #{tomcat_war_file}")
 
     template_file = File.read(File.expand_path(context_template_file, __FILE__))
@@ -180,12 +179,11 @@ namespace :capitomcat do
   end
 
   # Upload context template string to remote server
-  def upload_context_file
-    # local variables
+  def upload_context_file(tomcat_war_file)
     upload_user = fetch(:user)
     tomcat_context_file = fetch(:tomcat_context_file)
     tomcat_user = fetch(:tomcat_user)
-    context_template = get_context_template
+    context_template = get_context_template(tomcat_context_file, tomcat_war_file)
 
     temp_upload_file = '/tmp/' + File.basename(tomcat_context_file)
     temp_upload_file = timestamp_filename(temp_upload_file)
@@ -197,7 +195,6 @@ namespace :capitomcat do
 
   # Clean-up work directory
   def cleanup_work_dir
-    # local variables
     tomcat_work_dir = fetch(:tomcat_work_dir)
     tomcat_user = fetch(:tomcat_user)
 
@@ -207,10 +204,9 @@ namespace :capitomcat do
       warn('Tomcat work directory does not exist.')
     end
   end
-  
+
   # Clean-up work directory
-  def cleanup_unpacked_dir
-    # local variables
+  def cleanup_unpacked_dir(tomcat_war_file)
     tomcat_user = fetch(:tomcat_user)
     tomcat_war_file = fetch(:tomcat_war_file)
     tomcat_unpacked_dir = tomcat_war_file.sub('.war', '')
@@ -287,7 +283,6 @@ namespace :capitomcat do
   # Execute the Tomcat command
   # it executes the Tomcat command in background. and sleeps for several sec after executing.
   def execute_tomcat_cmd(arg)
-    # local variables
     puts "use_background_tomcat_cmd --> #{fetch(:use_background_tomcat_cmd)}"
     use_background = if fetch(:use_background_tomcat_cmd).to_s.length > 0
                        fetch(:use_background_tomcat_cmd).to_bool
@@ -302,23 +297,15 @@ namespace :capitomcat do
     end
   end
 
-  # Test if dir is existing
   def dir_exist?(dir)
     _test = capture("echo `if [ -d '#{dir}' ] ; then echo 'true' ; else echo 'false' ; fi`").to_s
-    if _test.eql?('true')
-      return true
-    else
-      return false
-    end
+
+    _test.eql?('true')
   end
 
-  # Test if file is existing
   def file_exist?(file)
     _test = capture("echo `if [ -e '#{file}' ] ; then echo 'true' ; else echo 'false' ; fi`").to_s
-    if _test.eql?('true')
-      return true
-    else
-      return false
-    end
+
+    _test.eql?('true')
   end
 end

--- a/lib/capitomcat/tasks/deploy.cap
+++ b/lib/capitomcat/tasks/deploy.cap
@@ -39,23 +39,19 @@ namespace :capitomcat do
   task :deploy do
     set :elb_instance_registration_wait_seconds, 300
 
-    aws_elb_manager = Capitomcat::AwsElbManager.new(
-      access_key_id: fetch(:aws_access_key_id),
-      region: fetch(:aws_region),
-      secret_access_key: fetch(:aws_secret_access_key),
-      load_balancer_name: fetch(:load_balancer_name)
-    )
+    if elb_defined?
+      aws_elb_manager = Capitomcat::AwsElbManager.new(
+        access_key_id: fetch(:aws_access_key_id),
+        region: fetch(:aws_region),
+        secret_access_key: fetch(:aws_secret_access_key),
+        load_balancer_name: fetch(:load_balancer_name)
+      )
+    end
 
     on roles(:app), in: get_parallelism, wait: 5 do |hosts|
-      current_instance_id = hosts.properties.fetch(:instance_id)
-
-      aws_elb_manager.deregister_instance(current_instance_id)
-      info 'Waiting for instance to be deregistered from Loadbalancer'
-      wait_for_instance_state(
-        aws_elb_manager: aws_elb_manager,
-        instance_id: current_instance_id,
-        state: 'OutOfService'
-      )
+      if elb_defined?
+        deregister_instance(hosts.properties.fetch(:instance_id), aws_elb_manager)
+      end
 
       local_war_file = fetch(:local_war_file)
       tomcat_war_file = fetch(:tomcat_war_file)
@@ -76,13 +72,9 @@ namespace :capitomcat do
       start_tomcat
       check_tomcat_started
 
-      aws_elb_manager.register_instance(current_instance_id)
-      info 'Waiting for instance to be registered with Loadbalancer'
-      wait_for_instance_state(
-        aws_elb_manager: aws_elb_manager,
-        instance_id: current_instance_id,
-        state: 'InService'
-      )
+      if elb_defined?
+        register_instance(hosts.properties.fetch(:instance_id), aws_elb_manager)
+      end
     end
   end
 
@@ -353,5 +345,29 @@ namespace :capitomcat do
         raise "Instance: #{instance_id} not in #{instance_state} after #{count} seconds"
       end
     end until(instance_state == state)
+  end
+
+  def elb_defined?
+    !fetch(:load_balancer_name, nil).nil?
+  end
+
+  def deregister_instance(instance_id, aws_elb_manager)
+    aws_elb_manager.deregister_instance(instance_id)
+    info 'Waiting for instance to be deregistered from Loadbalancer'
+    wait_for_instance_state(
+      aws_elb_manager: aws_elb_manager,
+      instance_id: instance_id,
+      state: 'OutOfService'
+    )
+  end
+
+  def register_instance(instance_id, aws_elb_manager)
+    aws_elb_manager.register_instance(instance_id)
+    info 'Waiting for instance to be registered with Loadbalancer'
+    wait_for_instance_state(
+      aws_elb_manager: aws_elb_manager,
+      instance_id: instance_id,
+      state: 'InService'
+    )
   end
 end

--- a/lib/capitomcat/tasks/deploy.cap
+++ b/lib/capitomcat/tasks/deploy.cap
@@ -176,13 +176,12 @@ namespace :capitomcat do
   def get_context_template(context_template_file, tomcat_war_file)
     raise('Context template file does not existing.') if !File.exists?(context_template_file)
 
-  for erb file
     tomcat_context_path = fetch(:tomcat_context_path)
     info ("#{tomcat_context_path}, #{tomcat_war_file}")
 
     template_file = File.read(File.expand_path(context_template_file, __FILE__))
     template = ERB.new(template_file)
-    return template.result(binding)
+    template.result(binding)
   end
 
   # Upload context template string to remote server

--- a/lib/capitomcat/tasks/deploy.cap
+++ b/lib/capitomcat/tasks/deploy.cap
@@ -36,10 +36,17 @@ namespace :capitomcat do
 
   task :deploy do
     on roles(:app), in: get_parallelism, wait: 5 do |hosts|
-      if fetch(:local_war_file).is_a?(Array) and fetch(:tomcat_war_file).is_a?(Array)
-        deploy_war(fetch(:local_war_file), fetch(:tomcat_war_file))
-      elsif fetch(:local_war_file).is_a?(String) and fetch(:tomcat_war_file).is_a?(String)
-        deploy_war(fetch(:local_war_file), fetch(:tomcat_war_file))
+      local_war_file = fetch(:local_war_file)
+      tomcat_war_file = fetch(:tomcat_war_file)
+
+      if local_war_file.is_a?(Array) and tomcat_war_file.is_a?(Array)
+        raise("Local and Remote files must match")
+
+        local_war_file.times do |i|
+          deploy_war(local_war_file[i], tomcat_war_file[i])
+        end
+      elsif local_war_file.is_a?(String) and fetch(:tomcat_war_file).is_a?(String)
+        deploy_war(local_war_file, tomcat_war_file)
       else
         raise("War inputs are mismatched")
       end
@@ -208,7 +215,6 @@ namespace :capitomcat do
   # Clean-up work directory
   def cleanup_unpacked_dir(tomcat_war_file)
     tomcat_user = fetch(:tomcat_user)
-    tomcat_war_file = fetch(:tomcat_war_file)
     tomcat_unpacked_dir = tomcat_war_file.sub('.war', '')
 
     if dir_exist?(tomcat_unpacked_dir)
@@ -238,13 +244,11 @@ namespace :capitomcat do
     end
   end
 
-  # Copy the file and remove after copy
   def clean_after_copy (file, destination, sudo_user)
-    # Change permission
     execute :chmod, '666', file
 
-    # Copy file to destination
     target_dir = File.dirname(destination)
+
     if dir_exist?(target_dir)
       execute :sudo, '-u', sudo_user, :cp, file, destination
     else
@@ -252,10 +256,11 @@ namespace :capitomcat do
       execute :sudo, '-u', sudo_user, :mkdir, '-p', target_dir
       execute :sudo, '-u', sudo_user, :cp, file, destination
     end
+
     if file_exist?(file)
       execute :rm, '-f', file
     else
-      warn("The target file to remove does not exist : #{file}")
+      warn("The target file to remove does not exist: #{file}")
     end
   end
 
@@ -267,7 +272,7 @@ namespace :capitomcat do
       execute :sudo, :chown, user, file
       execute :rm, '-f', file
     else
-      warn("The target file to remove does not exist : #{file}")
+      warn("The target file to remove does not exist: #{file}")
     end
   end
 
@@ -290,6 +295,7 @@ namespace :capitomcat do
                        true # Default is use background command which force not attaching tty(tty=UNKNOWN)
                      end
     tomcat_cmd = fetch(:tomcat_cmd)
+
     if use_background
       execute("echo `nohup sudo #{get_sudo_user_tomcat_cmd} #{tomcat_cmd} #{arg}& > /dev/null 2>&1` && sleep 1")
     else

--- a/lib/capitomcat/tasks/deploy.cap
+++ b/lib/capitomcat/tasks/deploy.cap
@@ -40,7 +40,7 @@ namespace :capitomcat do
       tomcat_war_file = fetch(:tomcat_war_file)
 
       if local_war_file.is_a?(Array) and tomcat_war_file.is_a?(Array)
-        raise("Local and Remote files must match")
+        raise("Local and Remote files must match") if local_war_file.length != tomcat_war_file.length
 
         local_war_file.times do |i|
           deploy_war(local_war_file[i], tomcat_war_file[i])

--- a/lib/capitomcat/tasks/deploy.cap
+++ b/lib/capitomcat/tasks/deploy.cap
@@ -50,6 +50,10 @@ namespace :capitomcat do
       else
         raise("War inputs are mismatched")
       end
+
+      info 'Start Tomcat'
+      start_tomcat
+      check_tomcat_started
     end
   end
 
@@ -70,10 +74,6 @@ namespace :capitomcat do
 
       info 'Clean Unpacked WAR directory'
       cleanup_unpacked_dir(tomcat_war_file)
-
-      info 'Start Tomcat'
-      start_tomcat
-      check_tomcat_started
     else
       info 'Stop Tomcat'
       stop_tomcat
@@ -87,10 +87,6 @@ namespace :capitomcat do
 
       info 'Clean Work directory'
       cleanup_work_dir
-
-      info 'Start Tomcat'
-      start_tomcat
-      check_tomcat_started
     end
   end
 


### PR DESCRIPTION
`netstat` check on Ubuntu with Tomcat 8 seems a little unreliable.

Using `curl` we can check if requests are being served. A non-zero exit code is returned if Tomcat isn't serving requests.